### PR TITLE
Add a name for validity

### DIFF
--- a/cnpt/deployment/kubernetes/agent-daemonset-1.8.yaml
+++ b/cnpt/deployment/kubernetes/agent-daemonset-1.8.yaml
@@ -1,6 +1,7 @@
-kind: DaemonSet
 apiVersion: apps/v1beta2
+kind: DaemonSet
 metadata:
+  name: cnpt-agent
   labels:
     app: agent
 spec:


### PR DESCRIPTION
 Fixes #19

## What
Fixes the YAML on the CNPT DaemonSet to be valid

## Why
`kubectl apply -f` fails otherwise